### PR TITLE
Project V.I.D - AdjustableRunningMechanics- v1.6.4

### DIFF
--- a/Assets/CatStoneAssets/Scripts/PlayerControllerScript.cs
+++ b/Assets/CatStoneAssets/Scripts/PlayerControllerScript.cs
@@ -49,6 +49,9 @@ public class PlayerControllerScript : MonoBehaviour
     //floats that constantly check where the hand positions are via normalized vectors.
     public float leftHandPositionConstantCheck, rightHandPositionConstantCheck;
 
+    //The offset threshold for where the running mechanic triggers (0 = hands have to pass height of headset).
+    public float handRunningOffsetPosition = -0.5f;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -82,12 +85,12 @@ public class PlayerControllerScript : MonoBehaviour
             motiontimeCounter += Time.deltaTime;
 
             //Constantly set the players hand positions to find if they are swapping.
-            if(openXRLeftControllerStabilized.transform.localPosition.normalized.y > -.5){
+            if(openXRLeftControllerStabilized.transform.localPosition.normalized.y > handRunningOffsetPosition){
                 leftHandPositionConstantCheck = 1;
             }else{
                 leftHandPositionConstantCheck = -1;
             }
-            if(openXRRightControllerStabilized.transform.localPosition.normalized.y > -.5){
+            if(openXRRightControllerStabilized.transform.localPosition.normalized.y > handRunningOffsetPosition){
                 rightHandPositionConstantCheck = 1;
             }else{
                 rightHandPositionConstantCheck = -1;
@@ -99,12 +102,12 @@ public class PlayerControllerScript : MonoBehaviour
             //Debug.Log("LeftHandYPosition: " + openXRLeftControllerStabilized.transform.localPosition.normalized.y);
             //Debug.Log("RighttHandYPosition: " + openXRRightControllerStabilized.transform.localPosition.normalized.y);
 
-            if(openXRLeftControllerStabilized.transform.localPosition.normalized.y > -.5){
+            if(openXRLeftControllerStabilized.transform.localPosition.normalized.y > handRunningOffsetPosition){
                 leftHandPositionLastCheck = 1;
             }else{
                 leftHandPositionLastCheck = -1;
             }
-            if(openXRRightControllerStabilized.transform.localPosition.normalized.y > -.5){
+            if(openXRRightControllerStabilized.transform.localPosition.normalized.y > handRunningOffsetPosition){
                 rightHandPositionLastCheck = 1;
             }else{
                 rightHandPositionLastCheck = -1;

--- a/Assets/CatStoneAssets/Scripts/PlayerControllerScript.cs
+++ b/Assets/CatStoneAssets/Scripts/PlayerControllerScript.cs
@@ -78,15 +78,16 @@ public class PlayerControllerScript : MonoBehaviour
         //This block of code sets the position of the hands depending on timer frequency.
         if(motiontimeCounter < playerRunningMotionCheckTimer){
             //Increase the time counter to repeatedly gather position points of the hands.
+            //NOTE : It's set to -0.5 due to assumptions that the average positions of people's hands being halfway down their body.
             motiontimeCounter += Time.deltaTime;
 
             //Constantly set the players hand positions to find if they are swapping.
-            if(openXRLeftControllerStabilized.transform.localPosition.normalized.y > 0){
+            if(openXRLeftControllerStabilized.transform.localPosition.normalized.y > -.5){
                 leftHandPositionConstantCheck = 1;
             }else{
                 leftHandPositionConstantCheck = -1;
             }
-            if(openXRRightControllerStabilized.transform.localPosition.normalized.y > 0){
+            if(openXRRightControllerStabilized.transform.localPosition.normalized.y > -.5){
                 rightHandPositionConstantCheck = 1;
             }else{
                 rightHandPositionConstantCheck = -1;
@@ -98,25 +99,17 @@ public class PlayerControllerScript : MonoBehaviour
             //Debug.Log("LeftHandYPosition: " + openXRLeftControllerStabilized.transform.localPosition.normalized.y);
             //Debug.Log("RighttHandYPosition: " + openXRRightControllerStabilized.transform.localPosition.normalized.y);
 
-            if(openXRLeftControllerStabilized.transform.localPosition.normalized.y > 0){
+            if(openXRLeftControllerStabilized.transform.localPosition.normalized.y > -.5){
                 leftHandPositionLastCheck = 1;
             }else{
                 leftHandPositionLastCheck = -1;
             }
-            if(openXRRightControllerStabilized.transform.localPosition.normalized.y > 0){
+            if(openXRRightControllerStabilized.transform.localPosition.normalized.y > -.5){
                 rightHandPositionLastCheck = 1;
             }else{
                 rightHandPositionLastCheck = -1;
             }
             motiontimeCounter = 0;
-
-            /*Sets a bool if the polarization of hands have changed (One hand has moved up/down the last check)
-            if(){
-                areHandsMoving = false;
-            }else{
-                areHandsMoving = true;
-            }
-            */
         }
         
         //This block sets the running state. If the hands have polar differences and recently changed.


### PR DESCRIPTION
Added a way to adjust the offset of the running mechanic via a float. 
Would need to interact with a settings menu for this to work.
Right now, set a base running mechanic float to be -0.5f.

This means, that the player has to pass their hand 0.5units (Roughly one alternate arm swing) away from their headset on the Y-axis, to trigger the running mechanic.